### PR TITLE
Snippet to update a CS bucket's value which is the owner's key id.

### DIFF
--- a/riak_cs_bucket_update_value.erl
+++ b/riak_cs_bucket_update_value.erl
@@ -1,0 +1,15 @@
+% value is the Owner Key Id
+
+OwnerToSet = <<"0">>.
+
+{ok,C} = riak:local_client(),
+
+case catch C:get(<<"moss.buckets">>,<<"backups">>,[{pr,all}]) of
+    {ok,Obj} ->
+        UpdatedObj = riak_object:update_value(Obj, OwnerToSet),
+        NewObj = riak_object:apply_updates(UpdatedObj),
+        Res = (catch C:put(NewObj,[{pw,all}])),
+        io:format("Put result: ~p~n",[Res]);
+    GetError ->
+        io:format("Error retrieving Riak object: ~p~n", [GetError])
+end.


### PR DESCRIPTION
A snippet updating a CS bucket's value which happens to be its owner's key id.
